### PR TITLE
Update OWNERS and remove maintainers from thoth.yaml

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -15,11 +15,6 @@ managers:
   - name: info
   - name: version
     configuration:
-      maintainers:
-        - goern
-        - harshad16
-        - pacospace
-        - eldritchjs
       assignees:
         - sesheta
       labels: [bot]

--- a/OWNERS
+++ b/OWNERS
@@ -4,8 +4,8 @@ approvers:
   - goern
   - fridex
   - eldritchjs
+  - codificat
 reviewers:
-  - pacospace
   - harshad16
   - kpostoffice
   - eldritchjs


### PR DESCRIPTION
## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

- Add myself as approver
- Remove the list of maintainers from `.thoth.yaml` to avoid redundancy

## Description

<!--- Describe your changes in detail -->
About removing maintainers from `.thoth.yaml`: Kebechet bot should use the [approvers list from OWNERS](https://thoth-station.ninja/docs/developers/kebechet/managers/version.html#configuration).